### PR TITLE
Fix NPE when getInvitedId is null (game in progress or game without invite)

### DIFF
--- a/src/main/java/me/desht/chesscraft/commands/JoinCommand.java
+++ b/src/main/java/me/desht/chesscraft/commands/JoinCommand.java
@@ -38,7 +38,7 @@ public class JoinCommand extends ChessAbstractCommand {
 		} else {
 			// find a game (or games) with an invitation for us
 			for (ChessGame game : cMgr.listGames()) {
-				if (game.getInvitedId().equals(player.getUniqueId())) {
+				if ((game.getInvitedId() != null) && (game.getInvitedId().equals(player.getUniqueId()))) {
 					colour = game.addPlayer(player.getUniqueId().toString(), player.getDisplayName());
 					gameName = game.getName();
 				}


### PR DESCRIPTION
When one or more other games are in progress on other boards or games have been created but no player invited, it causes an NPE when any player runs "/chess join". This simple null check will fix this error without impacting any game logic.
